### PR TITLE
Add badge to pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ckit
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/grafana/ckit.svg)](https://pkg.go.dev/github.com/grafana/ckit)
+
 ckit (clustering toolkit) is a lightweight package for creating clusters that
 use [consistent hashing][] for workload distribution.
 


### PR DESCRIPTION
Add badge for the pkg.go.dev reference, where docs for ckit are hosted.

(At the time of writing pkg.go.dev doesn't have the docs yet, but it will).