### PR TITLE
gossiphttp: fix open streams metric

### DIFF
--- a/internal/gossiphttp/transport.go
+++ b/internal/gossiphttp/transport.go
@@ -467,8 +467,6 @@ func (t *Transport) DialTimeout(addr string, timeout time.Duration) (net.Conn, e
 	var readMut sync.Mutex
 	readCnd := sync.NewCond(&readMut)
 
-	t.metrics.openStreams.Inc()
-
 	pr, pw := io.Pipe()
 
 	req := &http.Request{
@@ -494,6 +492,8 @@ func (t *Transport) DialTimeout(addr string, timeout time.Duration) (net.Conn, e
 		}
 		return nil, err
 	}
+
+	t.metrics.openStreams.Inc()
 
 	packetsClient := &http2Stream{
 		r: resp.Body,


### PR DESCRIPTION
The open streams metric was being incremented before the request succeeded, and only decremented if the request succeeded and the resulting stream was closed.

This means that if the request timed out (or failed for another reason), the metric would be permanently incremented, incorrectly appearing to leak a connection.