### PR TITLE
Change semantics around calling Start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 .vscode/
 .DS_Store
+vendor/

--- a/node.go
+++ b/node.go
@@ -122,13 +122,15 @@ type Node struct {
 //
 // Before starting the Node, the caller has to wire up the Node's HTTP handlers
 // on the base route provided by the Handler method.
+//
 // If Node is intended to be reachable over non-TLS HTTP/2 connections, then
 // the http.Server the routes are registered on must make use of the
 // golang.org/x/net/http2/h2c package to enable upgrading incoming plain HTTP
 // connections to HTTP/2.
+//
 // Similarly, if the Node is intended to initiate non-TLS outgoing connections,
-// the provided cli should be configured properly (with AllowHTTP: true and a
-// custom DialTLS function).
+// the provided cli should be configured properly (with AllowHTTP set to true
+// and using a custom DialTLS function to create a non-TLS net.Conn).
 func NewNode(cli *http.Client, cfg Config) (*Node, error) {
 	if err := cfg.validate(); err != nil {
 		return nil, err
@@ -225,14 +227,10 @@ func (n *Node) Metrics() prometheus.Collector { return n.m }
 // with an HTTP server before starting the Node.
 func (n *Node) Handler() (string, http.Handler) { return n.baseRoute, n.handler }
 
-// Start runs the Node for clustering with a list of peers to connect to. peers
-// can be an empty list if there is are no peers to connect to; other peers can
-// then connect to this node in their own Start methods.
+// Start starts the Node with a set of peers to connect to. Start may be called
+// multiple times to add additional peers into the memberlist.
 //
-// Start may be called multiple times to reconnect to a different set of peers.
-// Node will be set into StateViewer every time Start is called.
-//
-// Start may not be called after the Node has been stopped.
+// Start may not be called after [Stop] has been called.
 func (n *Node) Start(peers []string) error {
 	n.shutdownMut.Lock()
 	defer n.shutdownMut.Unlock()
@@ -245,29 +243,20 @@ func (n *Node) Start(peers []string) error {
 		return ErrStopped
 	}
 
-	_, err := n.ml.Join(peers)
-	if err != nil {
-		return fmt.Errorf("failed to join memberlist: %w", err)
-	}
-
-	// Force ourselves back into the pending state. This MUST be done after the
-	// join: join does a state sync and updates our lamport clock.
-	// NOTE: We delay taking stateMut here, because under certain conditions,
-	// it may be contested with another call when merging remote state inside
-	// of Join, leading to a deadlock.
-	n.stateMut.Lock()
-	defer n.stateMut.Unlock()
-	if err := n.changeState(peer.StateViewer, nil); err != nil {
-		return err
-	}
-
 	if n.runCancel == nil {
 		ctx, cancel := context.WithCancel(context.Background())
 		go n.run(ctx)
 		n.runCancel = cancel
 	}
 
-	return nil
+	_, err := n.ml.Join(peers)
+	if err != nil {
+		return fmt.Errorf("failed to join memberlist: %w", err)
+	}
+
+	// Broadcast our current state of the node to all peers now that our lamport
+	// clock is roughly synchronized.
+	return n.broadcastCurrentState()
 }
 
 func (n *Node) run(ctx context.Context) {
@@ -288,6 +277,31 @@ func (n *Node) run(ctx context.Context) {
 
 		n.notifyObservers(peers)
 	}
+}
+
+// broadcastCurrentState queues a message to send the current state of the node
+// to the cluster. This should be done after joining a new set of nodes once
+// the lamport clock is synchronized.
+func (n *Node) broadcastCurrentState() error {
+	n.stateMut.RLock()
+	defer n.stateMut.RUnlock()
+
+	stateMsg := messages.State{
+		NodeName: n.cfg.Name,
+		NewState: n.localState,
+		Time:     n.clock.Tick(),
+	}
+
+	// Treat the stateMsg as if it was received externally to track our own state
+	// along with other nodes.
+	n.handleStateMessage(stateMsg)
+
+	bcast, err := messages.Broadcast(&stateMsg, nil)
+	if err != nil {
+		return err
+	}
+	n.broadcasts.QueueBroadcast(bcast)
+	return nil
 }
 
 // Stop stops the Node, removing it from the cluster. Callers should first


### PR DESCRIPTION
This PR makes two changes across two commits around calling Start:

For the first change: Start will no longer report an error if a name conflict is detected following a push/pull. This fixes an issue where name conflicts caused the memberlist to be permanently closed, preventing any new messages from being gossiped. 

It is roughly safe to remove this behavior; due to the memberlist being eventually consistent, it's never been possible for Start to guarantee that there is no naming conflict with just the push/pull events, especially if two nodes with the same name connect to two different sets of seed nodes. 

For the second change: Start will no longer reset its state to Viewer when Start is called. This behavior prevented Start from being used to correct split-brain issues, where users of ckit periodically reinvoke Start with the full set of peers. The previous behavior assumed that calling Start twice would fully reset the memberlist, but that's not true; calling Start twice will only expand the list of peers in the memberlist. 

Additionally, @tpaschalis and I talked offline about decoupling Start into NewNode (which would call `n.run` internally) and Join (which would only join new nodes in the memberlist). I decided to not go for that approach, since moving `n.run` and the initial state change to Viewer to NewNode would prevent observers from being notified of the local node from joining the cluster.

Related to grafana/agent#3919.