### PR TITLE
peer: implement json.Marshaler/Unmarshaler interfaces

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1,6 +1,8 @@
 // Package peer describes a ckit peer.
 package peer
 
+import "encoding/json"
+
 // Peer is a discovered node within the cluster.
 type Peer struct {
 	Name  string // Name of the Peer. Unique across the cluster.
@@ -11,3 +13,19 @@ type Peer struct {
 
 // String returns the name of p.
 func (p Peer) String() string { return p.Name }
+
+// MarshalJSON implements json.Marshaler.
+func (p Peer) MarshalJSON() ([]byte, error) {
+	type peerStatusJSON struct {
+		Name  string `json:"name"`   // Name of the Peer. Unique across the cluster.
+		Addr  string `json:"addr"`   // host:port address of the peer.
+		Self  bool   `json:"isSelf"` // True if Peer is the local Node.
+		State string `json:"state"`  // State of the peer.
+	}
+	return json.Marshal(&peerStatusJSON{
+		Name:  p.Name,
+		Addr:  p.Addr,
+		Self:  p.Self,
+		State: p.State.String(),
+	})
+}

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -14,13 +14,13 @@ type Peer struct {
 // String returns the name of p.
 func (p Peer) String() string { return p.Name }
 
-// MarshalJSON implements json.Marshaler.
+// MarshalJSON implements [json.Marshaler].
 func (p Peer) MarshalJSON() ([]byte, error) {
 	type peerStatusJSON struct {
-		Name  string `json:"name"`   // Name of the Peer. Unique across the cluster.
-		Addr  string `json:"addr"`   // host:port address of the peer.
-		Self  bool   `json:"isSelf"` // True if Peer is the local Node.
-		State string `json:"state"`  // State of the peer.
+		Name  string `json:"name"`
+		Addr  string `json:"addr"`
+		Self  bool   `json:"isSelf"`
+		State string `json:"state"`
 	}
 	return json.Marshal(&peerStatusJSON{
 		Name:  p.Name,
@@ -28,4 +28,31 @@ func (p Peer) MarshalJSON() ([]byte, error) {
 		Self:  p.Self,
 		State: p.State.String(),
 	})
+}
+
+// UnmarshalJSON implements [json.Unmarshaler].
+func (p *Peer) UnmarshalJSON(b []byte) error {
+	type peerStatusJSON struct {
+		Name  string `json:"name"`
+		Addr  string `json:"addr"`
+		Self  bool   `json:"isSelf"`
+		State string `json:"state"`
+	}
+
+	var psj peerStatusJSON
+
+	if err := json.Unmarshal(b, &psj); err != nil {
+		return err
+	}
+	state, err := toState(psj.State)
+	if err != nil {
+		return err
+	}
+
+	p.Name = psj.Name
+	p.Addr = psj.Addr
+	p.Self = psj.Self
+	p.State = state
+
+	return nil
 }

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -1,0 +1,26 @@
+package peer
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONRepresentation(t *testing.T) {
+	p := Peer{
+		Name:  "test-peer",
+		Addr:  "localhost",
+		Self:  true,
+		State: StateParticipant,
+	}
+	var q Peer
+
+	b, err := json.Marshal(p)
+	require.NoError(t, err)
+
+	err = json.Unmarshal(b, &q)
+	require.NoError(t, err)
+
+	require.Equal(t, p, q)
+}

--- a/peer/state.go
+++ b/peer/state.go
@@ -42,3 +42,16 @@ func (s State) String() string {
 		return fmt.Sprintf("<unknown state %d>", s)
 	}
 }
+
+func toState(s string) (State, error) {
+	switch s {
+	case "viewer":
+		return StateViewer, nil
+	case "participant":
+		return StateParticipant, nil
+	case "terminating":
+		return StateTerminating, nil
+	}
+
+	return 0, fmt.Errorf("unknown state %q", s)
+}


### PR DESCRIPTION
This would allow downstream users of `peer.Peer` to able to transfer peer information over an API without having to wrap around it.

Currently, explicitly implementing json.Marshaler is made so that the State can be transferred with its human-readable string representation.

Are there any objections with this?