### PR TITLE
change network filter from ip4 to ip

### DIFF
--- a/node.go
+++ b/node.go
@@ -146,7 +146,7 @@ func NewNode(cli *http.Client, cfg Config) (*Node, error) {
 		return nil, fmt.Errorf("failed to read advertise address: %w", err)
 	}
 
-	advertiseIP, err := net.ResolveIPAddr("ip4", advertiseAddr)
+	advertiseIP, err := net.ResolveIPAddr("ip", advertiseAddr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to lookup advertise address %q: %w", advertiseAddr, err)
 	}


### PR DESCRIPTION
In https://github.com/grafana/ckit/pull/26 I added the possibility to retrieve IPv6 addresses from network interface but I did not see that there was another ip4 filter in the creation of the node.

With the change ckit should hopefully fully support IPv6 addresses