### PR TITLE
Add EnableTLS config

### DIFF
--- a/node.go
+++ b/node.go
@@ -62,6 +62,11 @@ type Config struct {
 	// Nodes are prevented from joining a cluster with an explicit label if
 	// they do not share the same label.
 	Label string
+
+	// EnableTLS optionally specifies whether TLS should be
+	// used for communication between peers.
+	// Defaults to false.
+	EnableTLS bool
 }
 
 func (c *Config) validate() error {
@@ -160,6 +165,7 @@ func NewNode(cli *http.Client, cfg Config) (*Node, error) {
 		Log:           cfg.Log,
 		Client:        cli,
 		PacketTimeout: 1 * time.Second,
+		UseHTTPS:      cfg.EnableTLS,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to build transport: %w", err)


### PR DESCRIPTION
This PR exposes the node config required to enable HTTPS in the transport used for gossiping.

This is a dependency for https://github.com/grafana/alloy/pull/1724, which fixes https://github.com/grafana/alloy/issues/367.

### Why is this change required
My organization runs alloy pods in environments that require all pod communications over HTTPS and require TLS encryption. When enabling clustering, we noticed that communication between pods was blocked because it was going over HTTP.