### PR TITLE
Surface memberlist logs on adequate level

### DIFF
--- a/logging.go
+++ b/logging.go
@@ -1,0 +1,37 @@
+package ckit
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+)
+
+// memberListOutputLogger will do best-effort classification of the logging level that memberlist uses and use the
+// corresponding level when logging with logger. This helps us surface only desired log messages from memberlist.
+// If classification fails, debug level is used as a fallback.
+type memberListOutputLogger struct {
+	logger log.Logger
+}
+
+var _ io.Writer = (*memberListOutputLogger)(nil)
+
+func (m *memberListOutputLogger) Write(p []byte) (int, error) {
+	var err error
+
+	if bytes.Contains(p, []byte("[ERR]")) {
+		err = level.Error(m.logger).Log("msg", p)
+	} else if bytes.Contains(p, []byte("[WARN]")) {
+		err = level.Warn(m.logger).Log("msg", p)
+	} else if bytes.Contains(p, []byte("[INFO]")) {
+		err = level.Info(m.logger).Log("msg", p)
+	} else {
+		err = level.Debug(m.logger).Log("msg", p)
+	}
+
+	if err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}

--- a/logging.go
+++ b/logging.go
@@ -17,14 +17,20 @@ type memberListOutputLogger struct {
 
 var _ io.Writer = (*memberListOutputLogger)(nil)
 
+var (
+	errPrefix  = []byte("[ERR]")
+	warnPrefix = []byte("[WARN]")
+	infoPrefix = []byte("[INFO]")
+)
+
 func (m *memberListOutputLogger) Write(p []byte) (int, error) {
 	var err error
 
-	if bytes.Contains(p, []byte("[ERR]")) {
+	if bytes.HasPrefix(p, errPrefix) {
 		err = level.Error(m.logger).Log("msg", p)
-	} else if bytes.Contains(p, []byte("[WARN]")) {
+	} else if bytes.HasPrefix(p, warnPrefix) {
 		err = level.Warn(m.logger).Log("msg", p)
-	} else if bytes.Contains(p, []byte("[INFO]")) {
+	} else if bytes.HasPrefix(p, infoPrefix) {
 		err = level.Info(m.logger).Log("msg", p)
 	} else {
 		err = level.Debug(m.logger).Log("msg", p)

--- a/logging_test.go
+++ b/logging_test.go
@@ -1,0 +1,86 @@
+package ckit
+
+import (
+	"fmt"
+	golog "log"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogging(t *testing.T) {
+	cases := []struct {
+		name     string
+		message  string
+		expected string
+	}{
+		{
+			name:     "debug level",
+			message:  "[DEBUG] memberlist: Stream connection from=127.0.0.1:56631\n",
+			expected: `level="debug", msg="Stream connection from=127.0.0.1:56631"`,
+		},
+		{
+			name:     "info level",
+			message:  "[INFO] memberlist: Suspect node-a has failed, no acks received\n",
+			expected: `level="info", msg="Suspect node-a has failed, no acks received"`,
+		},
+		{
+			name:     "warn level",
+			message:  "[WARN] memberlist: Refuting a dead message (from: node-b)\n",
+			expected: `level="warn", msg="Refuting a dead message (from: node-b)"`,
+		},
+		{
+			name:     "error level",
+			message:  "[ERR] memberlist: Failed fallback TCP ping: io: read/write on closed pipe\n",
+			expected: `level="error", msg="Failed fallback TCP ping: io: read/write on closed pipe"`,
+		},
+		{
+			name:     "error without memberlist",
+			message:  "[ERR] Failed to shutdown transport: test\n",
+			expected: `level="error", msg="Failed to shutdown transport: test"`,
+		},
+		{
+			name:     "default level",
+			message:  "a message without level\n",
+			expected: `level="info", msg="a message without level"`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			capture := newCaptureLogger()
+			logger := newMemberListLogger(capture)
+			logger.Println(c.message)
+			require.Len(t, capture.lines, 1)
+			require.Equal(t, c.expected, capture.lines[0])
+		})
+	}
+}
+
+func newCaptureLogger() *captureLogger {
+	c := &captureLogger{
+		lines: make([]string, 0),
+	}
+	c.adapter = golog.New(c, "", 0)
+	return c
+}
+
+type captureLogger struct {
+	lines   []string
+	adapter *golog.Logger
+}
+
+func (c *captureLogger) Write(p []byte) (n int, err error) {
+	c.lines = append(c.lines, string(p))
+	return len(p), nil
+}
+
+func (c *captureLogger) Log(keyvals ...interface{}) error {
+	lineParts := make([]string, 0)
+	for i := 0; i < len(keyvals); i += 2 {
+		lineParts = append(lineParts, fmt.Sprintf("%v=%q", keyvals[i], keyvals[i+1]))
+	}
+	c.lines = append(c.lines, strings.Join(lineParts, ", "))
+	return nil
+}

--- a/node.go
+++ b/node.go
@@ -179,11 +179,12 @@ func NewNode(cli *http.Client, cfg Config) (*Node, error) {
 	mlc.Transport = httpTransport
 	mlc.AdvertiseAddr = advertiseIP.String()
 	mlc.AdvertisePort = advertisePort
-	mlc.LogOutput = io.Discard
 	mlc.Label = cfg.Label
 
 	if cfg.Log != nil {
-		mlc.LogOutput = &memberListOutputLogger{logger: log.With(cfg.Log, "component", "memberlist")}
+		mlc.Logger = newMemberListLogger(log.With(cfg.Log, "subsystem", "memberlist"))
+	} else {
+		mlc.LogOutput = io.Discard
 	}
 
 	n := &Node{

--- a/node.go
+++ b/node.go
@@ -14,15 +14,16 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/hashicorp/go-msgpack/codec"
+	"github.com/hashicorp/memberlist"
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/grafana/ckit/internal/gossiphttp"
 	"github.com/grafana/ckit/internal/lamport"
 	"github.com/grafana/ckit/internal/messages"
 	"github.com/grafana/ckit/internal/queue"
 	"github.com/grafana/ckit/peer"
 	"github.com/grafana/ckit/shard"
-	"github.com/hashicorp/go-msgpack/codec"
-	"github.com/hashicorp/memberlist"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (
@@ -182,7 +183,7 @@ func NewNode(cli *http.Client, cfg Config) (*Node, error) {
 	mlc.Label = cfg.Label
 
 	if cfg.Log != nil {
-		mlc.LogOutput = log.NewStdlibAdapter(level.Debug(log.With(cfg.Log, "component", "memberlist")))
+		mlc.LogOutput = &memberListOutputLogger{logger: log.With(cfg.Log, "component", "memberlist")}
 	}
 
 	n := &Node{


### PR DESCRIPTION
Sometimes `memberlist` can log an error or warning or even a useful info level logs. We currently only consume them on debug level. This PR:
* adds a way to classify the logs from `memberlist` and surface them on adequate level.
* changes the `component=memberlist` to `subsystem=memberlist`. We keep the extra label added by ckit itself instead of passing it to ckit, as there are also some logs in ckit that don't use any label at all. It's good to differentiate them.

Here are some samples from running the tests after the changes:
```
level=debug test=TestNode_State/nodes_can_restart_in_viewer_state ts=14:42:32.019 node=node-b subsystem=memberlist msg="Initiating push/pull sync with:  127.0.0.1:54637"

level=info test=TestNode_State/nodes_can_restart_in_viewer_state ts=14:42:32.019 node=node-a subsystem=memberlist msg="Updating address for left or failed node node-b from 127.0.0.1:54638 to 127.0.0.1:54652"
```

Note the correct `level=...` is based on `[<level>]` of the original message as expected.