### PR TITLE
Log string not []byte

### DIFF
--- a/logging.go
+++ b/logging.go
@@ -34,9 +34,9 @@ func newMemberListLogger(logger log.Logger) *golog.Logger {
 func (m *memberListOutputLogger) Write(p []byte) (int, error) {
 	var err error
 
-	sanitizeFn := func(dropPrefix []byte, msg []byte) []byte {
+	sanitizeFn := func(dropPrefix []byte, msg []byte) string {
 		noLevel := bytes.TrimSpace(bytes.TrimPrefix(msg, dropPrefix))
-		return bytes.TrimPrefix(noLevel, memberListPrefix)
+		return string(bytes.TrimPrefix(noLevel, memberListPrefix))
 	}
 
 	switch {


### PR DESCRIPTION
In https://github.com/grafana/ckit/pull/68 I logged `[]byte`, which was fine with the test setup I was using.

However, some logger implementations, such as the one in Alloy, will not handle `[]byte` values well and print this:
```
ts=2024-11-28T14:57:29.245855Z level=info msg="[83 117 115 112 101 99 116 32 110 49 32 104 97 115 32 102 97 105 108 101 100 44 32 110 111 32 97 99 107 115 32 114 101 99 101 105 118 101 100]" service=cluster subsystem=memberlist
```

So for convenience, I want to convert them to `string` right away. Tested with local Alloy build this time:
```
ts=2024-11-28T15:01:22.274525Z level=info msg="Marking n1 as failed, suspect timeout reached (0 peer confirmations)" service=cluster subsystem=memberlist
```