### PR TITLE
ckit: reduce overhead of rejoining cluster

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -25,12 +25,13 @@ const clusterNameLabel = "cluster_name"
 type metrics struct {
 	metricsutil.Container
 
-	gossipEventsTotal  *prometheus.CounterVec
-	nodePeers          *prometheus.GaugeVec
-	nodeUpdating       prometheus.Gauge
-	nodeUpdateDuration prometheus.Histogram
-	nodeObservers      prometheus.Gauge
-	nodeInfo           *metricsutil.InfoCollector
+	gossipEventsTotal     *prometheus.CounterVec
+	gossipBroadcastsTotal *prometheus.CounterVec
+	nodePeers             *prometheus.GaugeVec
+	nodeUpdating          prometheus.Gauge
+	nodeUpdateDuration    prometheus.Histogram
+	nodeObservers         prometheus.Gauge
+	nodeInfo              *metricsutil.InfoCollector
 }
 
 var _ prometheus.Collector = (*metrics)(nil)
@@ -41,6 +42,14 @@ func newMetrics(clusterName string) *metrics {
 	m.gossipEventsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "cluster_node_gossip_received_events_total",
 		Help: "Total number of gossip messages handled by the node.",
+		ConstLabels: prometheus.Labels{
+			clusterNameLabel: clusterName,
+		},
+	}, []string{"event"})
+
+	m.gossipBroadcastsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "cluster_node_gossip_broadcasts_total",
+		Help: "Total number of gossip messages broadcasted by the node.",
 		ConstLabels: prometheus.Labels{
 			clusterNameLabel: clusterName,
 		},
@@ -89,6 +98,7 @@ func newMetrics(clusterName string) *metrics {
 
 	m.Add(
 		m.gossipEventsTotal,
+		m.gossipBroadcastsTotal,
 		m.nodePeers,
 		m.nodeUpdating,
 		m.nodeUpdateDuration,


### PR DESCRIPTION
Previously, whenever a client would call Start to rejoin a cluster (and fix any potential split-brain issues), a new state message would be generated and broadcast to the cluster.

This resulted in a significant amount of gossip traffic as the cluster size increased: a cluster with 800 nodes rejoining every 15 seconds would result in around 640,000 state change messages being sent every 15 seconds (800 state changes sent to 800 nodes).

This logic only appeared neccessary due to a bug in correcting invalid state messages about our own node: if we get any message at all about our node which is newer than our local copy, only then should we broadcast a new message.

Fixing this bug removed the need for this logic, which will help reduce the amount of gossip generated when rejoining.

With this change, rejoining a node will only require one push/pull request per node being joined, and will result in no new broadcasts if all nodes are already up-to-date.

To help observe broadcast volume, a new `cluster_node_gossip_broadcasts_total` metric has been added.