### PR TITLE
perf(internal/messages): improve performance of broadcasting state

### DIFF
--- a/internal/messages/broadcast.go
+++ b/internal/messages/broadcast.go
@@ -6,6 +6,10 @@ import "github.com/hashicorp/memberlist"
 // being converted into a Broadcast.
 //
 // onDone will be called once the message has been broadcasted or invalidated.
+//
+// Queueing the resulting Broadcast will invalidate all previous broadcasts
+// for messages with the same name; this means that callers should only queue
+// newer messages.
 func Broadcast(m Message, onDone func()) (memberlist.Broadcast, error) {
 	bb, err := Encode(m)
 	if err != nil {
@@ -21,16 +25,32 @@ type broadcastWrapper struct {
 	onDone func()
 }
 
+// We want to implement [memberlist.NamedBroadcast] because it goes through a
+// fast path when queueing messages for broadcasting, where the Name is
+// stored in a map to immediately invalidate older messages with the same
+// Name.
+//
+// Without this, each time we queue a message, we call Invalidates on all
+// previously queued messages, for a total of N(N + 1) / 2 calls.
+var (
+	_ memberlist.Broadcast      = (*broadcastWrapper)(nil)
+	_ memberlist.NamedBroadcast = (*broadcastWrapper)(nil)
+)
+
 func (bw *broadcastWrapper) Invalidates(b memberlist.Broadcast) bool {
 	other, ok := b.(*broadcastWrapper)
 	if !ok {
 		return false
 	}
-	return bw.inner.Invalidates(other.inner)
+	return bw.inner.Name() == other.inner.Name()
 }
 
 func (bw *broadcastWrapper) Message() []byte {
 	return bw.data
+}
+
+func (bw *broadcastWrapper) Name() string {
+	return bw.inner.Name()
 }
 
 func (bw *broadcastWrapper) Finished() {

--- a/internal/messages/broadcast_test.go
+++ b/internal/messages/broadcast_test.go
@@ -1,0 +1,62 @@
+package messages_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/grafana/ckit/internal/lamport"
+	"github.com/grafana/ckit/internal/messages"
+	"github.com/grafana/ckit/peer"
+	"github.com/hashicorp/memberlist"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkBroadcast(b *testing.B) {
+	b.Run("Different names", func(b *testing.B) {
+		var broadcasts []memberlist.Broadcast
+
+		for i := range b.N {
+			bcast, err := messages.Broadcast(&messages.State{
+				NodeName: fmt.Sprintf("node-%d", i),
+				NewState: peer.StateParticipant,
+				Time:     lamport.Time(i),
+			}, nil)
+			require.NoError(b, err)
+
+			broadcasts = append(broadcasts, bcast)
+		}
+
+		var queue memberlist.TransmitLimitedQueue
+		queue.RetransmitMult = 4
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			queue.QueueBroadcast(broadcasts[i])
+		}
+	})
+
+	b.Run("Same name", func(b *testing.B) {
+		var broadcasts []memberlist.Broadcast
+
+		for i := range b.N {
+			bcast, err := messages.Broadcast(&messages.State{
+				NodeName: "node",
+				NewState: peer.StateParticipant,
+				Time:     lamport.Time(i),
+			}, nil)
+			require.NoError(b, err)
+
+			broadcasts = append(broadcasts, bcast)
+		}
+
+		var queue memberlist.TransmitLimitedQueue
+		queue.RetransmitMult = 4
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			queue.QueueBroadcast(broadcasts[i])
+		}
+	})
+}

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -42,13 +42,10 @@ type Message interface {
 	// Type returns the Type of the message. Type must be a known, valid type.
 	Type() Type
 
-	// Invalidates should return true if this message takes precedence over m.
-	Invalidates(m Message) bool
-
-	// Cache should return true if this Message should be cached into the local
-	// state. Messages in the local state will be synchronized with peers over
-	// time, and is useful for anti-entropy.
-	Cache() bool
+	// Name returns the name of the node this message is for. When queueing Messages
+	// for broadcast, newer messages immediately invalidate older messages with
+	// the same Name.
+	Name() string
 }
 
 // Encode encodes m into a byte slice that can be broadcast to other peers.

--- a/internal/messages/messages_test.go
+++ b/internal/messages/messages_test.go
@@ -53,6 +53,6 @@ type fakeMessage struct {
 	ty Type
 }
 
-func (fm fakeMessage) Type() Type                 { return fm.ty }
-func (fm fakeMessage) Invalidates(m Message) bool { return false }
-func (fm fakeMessage) Cache() bool                { return false }
+func (fm fakeMessage) Type() Type   { return fm.ty }
+func (fm fakeMessage) Name() string { return "" }
+func (fm fakeMessage) Cache() bool  { return false }

--- a/internal/messages/state.go
+++ b/internal/messages/state.go
@@ -27,14 +27,8 @@ var _ Message = (*State)(nil)
 // Type implements Message.
 func (s *State) Type() Type { return TypeState }
 
-// Invalidates implements Message.
-func (s *State) Invalidates(m Message) bool {
-	other, ok := m.(*State)
-	if !ok {
-		return false
-	}
-	return s.NodeName == other.NodeName && s.Time > other.Time
-}
+// Name implements Message.
+func (s *State) Name() string { return s.NodeName }
 
 // Cache implements Message.
 func (s *State) Cache() bool { return true }


### PR DESCRIPTION
The very first patch release of hashicorp/memberlist introduced a NamedBroadcast type to deal with a significant CPU overhead when queueing many messages for broadcasting in a busy cluster. ckit did not use it. 

Not implementing this interface causes queueing N messages to require N(N + 1) / 2 total calls to Invalidates; for a cluster where 5,000 nodes suddenly join, this is 12.5 million calls.

Implementing this interface makes queueing broadcasts several orders of magnitude faster, as seen in the benchmark results below:

    goos: darwin
    goarch: arm64
    pkg: github.com/grafana/ckit/internal/messages
    cpu: Apple M1 Max
                                 │ queue-before.txt │           queue-after.txt            │
                                 │      sec/op      │    sec/op     vs base                │
    Broadcast/Different_names-10    116215.5n ±  1%   418.8n ±  4%  -99.64% (p=0.000 n=10)
    Broadcast/Same_name-10             137.7n ± 12%   136.0n ± 23%        ~ (p=0.315 n=10)
    geomean                            4.000µ         238.7n        -94.03%

                                 │ queue-before.txt │           queue-after.txt           │
                                 │       B/op       │    B/op      vs base                │
    Broadcast/Different_names-10         82.00 ± 1%   153.50 ± 6%  +87.20% (p=0.000 n=10)
    Broadcast/Same_name-10               72.00 ± 0%    64.00 ± 0%  -11.11% (p=0.000 n=10)
    geomean                              76.84         99.12       +28.99%

                                 │ queue-before.txt │           queue-after.txt            │
                                 │    allocs/op     │ allocs/op   vs base                  │
    Broadcast/Different_names-10         1.000 ± 0%   1.000 ± 0%        ~ (p=1.000 n=10) ¹
    Broadcast/Same_name-10               2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
    geomean                              1.414        1.000       -29.29%
    ¹ all samples are equal

The CPU performance gains are significant enough that the marginal increase in memory is acceptable; queueing messages for 5,000 nodes will now be ~280x faster while only (briefly) requiring 765KB of memory.