### PR TITLE
misc: improvements to TCP usage, state handling, and convergence time 

### DIFF
--- a/internal/gossiphttp/transport.go
+++ b/internal/gossiphttp/transport.go
@@ -580,7 +580,17 @@ func (t *Transport) writeToSync(b []byte, addr string) {
 	req.Header.Set("Content-Type", ckitContentType)
 	resp, err := t.opts.Client.Do(req)
 	if err != nil || resp.StatusCode != http.StatusOK {
-		level.Debug(t.log).Log("msg", "failed to send message", "err", err, "status_code", resp.StatusCode)
+		level.Debug(t.log).Log("msg", "failed to send message", "err", err, "status_code", statusCodeValue(resp))
 		t.metrics.packetTxFailedTotal.Inc()
 	}
+}
+
+// statusCodeValue returns the value to use when logging an HTTP status code.
+// if resp is nil, statusCodeValue returns a string of "<no response>".
+// Otherwise, it returns the numeric status code.
+func statusCodeValue(resp *http.Response) any {
+	if resp == nil {
+		return "<no response>"
+	}
+	return resp.StatusCode
 }

--- a/internal/gossiphttp/transport.go
+++ b/internal/gossiphttp/transport.go
@@ -256,6 +256,10 @@ func (t *Transport) run(ctx context.Context) {
 				return
 			}
 
+			// TODO(rfratto): allowing for multiple workers to process outgoing packets
+			// can help minimize latency. grafana/dskit permits for 3 workers by default,
+			// but to tolerate unhealthy peers we should probably allow for twice the
+			// number of gossip peers.
 			pkt := v.(*outPacket)
 			t.metrics.packetTxTotal.Inc()
 			t.metrics.packetTxBytesTotal.Add(float64(len(pkt.Data)))
@@ -576,7 +580,7 @@ func (t *Transport) writeToSync(b []byte, addr string) {
 	req.Header.Set("Content-Type", ckitContentType)
 	resp, err := t.opts.Client.Do(req)
 	if err != nil || resp.StatusCode != http.StatusOK {
-		level.Debug(t.log).Log("msg", "failed to send message", "err", err)
+		level.Debug(t.log).Log("msg", "failed to send message", "err", err, "status_code", resp.StatusCode)
 		t.metrics.packetTxFailedTotal.Inc()
 	}
 }

--- a/node.go
+++ b/node.go
@@ -165,7 +165,7 @@ func NewNode(cli *http.Client, cfg Config) (*Node, error) {
 	httpTransport, transportMetrics, err := gossiphttp.NewTransport(gossiphttp.Options{
 		Log:           cfg.Log,
 		Client:        cli,
-		PacketTimeout: 1 * time.Second,
+		PacketTimeout: 5 * time.Second,
 		UseHTTPS:      cfg.EnableTLS,
 	})
 	if err != nil {
@@ -180,6 +180,11 @@ func NewNode(cli *http.Client, cfg Config) (*Node, error) {
 	mlc.AdvertiseAddr = advertiseIP.String()
 	mlc.AdvertisePort = advertisePort
 	mlc.Label = cfg.Label
+	mlc.ProbeInterval = 5 * time.Second
+	mlc.ProbeTimeout = 2 * time.Second
+	mlc.DisableTcpPings = true           // No point in TCP ping fallbacks when our transport is already HTTP/2.
+	mlc.UDPBufferSize = 10 * 1024 * 1024 // Our buffer size can be a bit higher since we use TCP (10 MiB).
+	mlc.TCPTimeout = 2 * time.Second
 
 	if cfg.Log != nil {
 		mlc.Logger = newMemberListLogger(log.With(cfg.Log, "subsystem", "memberlist"))

--- a/node.go
+++ b/node.go
@@ -357,6 +357,10 @@ func (n *Node) CurrentState() peer.State {
 //	StateParticipant -> StateTerminating
 //
 // Nodes intended to only be viewers should never transition to another state.
+//
+// It is valid to call ChangeState before calling [Node.Start], but may result
+// in more gossip messages for nodes which have rejoined the cluster. To
+// minimize network traffic, only call ChangeState after starting the Node.
 func (n *Node) ChangeState(ctx context.Context, to peer.State) error {
 	n.stateMut.Lock()
 	defer n.stateMut.Unlock()

--- a/node.go
+++ b/node.go
@@ -453,6 +453,7 @@ func (n *Node) storePeerState(msg messages.State) {
 	}
 }
 
+// handleStateMessage handles a state message from a peer. Returns true if the
 // message hasn't been seen before. The final return parameter will be the
 // message to broadcast: if msg is a stale message from a previous instance of
 // the local node, final will be an updated message reflecting the node's local


### PR DESCRIPTION
This was going to start as a single change but it ended up being a few. 

I started with finding an edge case where if a node finds a message about itself with the same lamport time as its most recent broadcast (but with a different state), it doesn't refute that state, leading to inconsistencies in the cluster. Recreating this scenario requires being really unlucky, but I believe it's possible to happen.

After fixing that, I noticed a few other things that needed to be fixed:

1. Each state change produced 3 lamport clock increases, which was unnecessary and made debugging annoying. 

2. While looking into flaking tests, I noticed TCP timeouts causing memberlist errors; I made the timeouts more generous and aligned them with the settings dskit uses for its memberlist.

3. Fix a flaky test where a node rejoining as a viewer (previously non-viewer) is not given a chance to refuse its state. 

I was initially a little concerned about the implications of that third fix; the initial reason states were cached for two sync cycles was to prevent a peer from flapping between a viewer state and a non-viewer state if its connection to the memberlist is faulty. 

After thinking about it more, I don't think I had to be concerned: memberlist is already pretty good at only removing a peer when it's appropriate. 