### PR TITLE
fix: Overflow on 32bit architectures when checking message length

### DIFF
--- a/internal/gossiphttp/message.go
+++ b/internal/gossiphttp/message.go
@@ -58,6 +58,7 @@ func readMessage(r io.Reader) ([]byte, error) {
 
 // writeMessage writes a message to an [io.Writer].
 func writeMessage(w io.Writer, message []byte) error {
+	// Note(salvacorts): We need to cast to uint to avoid overflows on 32-bit systems (e.g. arm docker images)
 	if uint(len(message)) > math.MaxUint32 {
 		return fmt.Errorf("message length %d exceeds size limit %d", len(message), uint32(math.MaxUint32))
 	}

--- a/internal/gossiphttp/message.go
+++ b/internal/gossiphttp/message.go
@@ -58,8 +58,8 @@ func readMessage(r io.Reader) ([]byte, error) {
 
 // writeMessage writes a message to an [io.Writer].
 func writeMessage(w io.Writer, message []byte) error {
-	if len(message) > math.MaxUint32 {
-		return fmt.Errorf("message length %d exceeds size limit %d", len(message), math.MaxUint32)
+	if uint(len(message)) > math.MaxUint32 {
+		return fmt.Errorf("message length %d exceeds size limit %d", len(message), uint32(math.MaxUint32))
 	}
 
 	header := headerPool.Get().(*header)


### PR DESCRIPTION
The Loki CI is failing to compile 32 bits ARM images
https://github.com/grafana/loki/actions/runs/17198690843/job/48785568512

Fixing https://github.com/grafana/ckit/pull/96