### PR TITLE
ci: add workflow for testing 32-bit builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,3 +37,17 @@ jobs:
         go-version: '1.23'
     - name: Test
       run: make test
+  test-32bit:
+    name: Test (32-bit)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v5
+      with:
+        persist-credentials: false
+    - name: Set up Go 1.23
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.23'
+    - name: Test
+      run: GOARCH=386 make test

--- a/internal/gossiphttp/message.go
+++ b/internal/gossiphttp/message.go
@@ -8,6 +8,25 @@ import (
 	"sync"
 )
 
+// NOTE(rfratto): Even though our messages can store up to 4 GiB
+// ([math.MaxUint32]), the effective limit on 32-bit platforms is 2 GiB
+// ([math.MaxInt32]), since slices are sized with a signed integer.
+//
+// Since ckit supports 32-bit builds we need to determine the platform-specific
+// maximum message length.
+//
+// To set [MaxMesasgeLength], we rely on how [math.MaxInt] is either equivalent
+// to [math.MaxInt32] or [math.MaxInt64] depending on the platform:
+//
+//   - 32-bit: [math.MaxUint32] & [math.MaxInt32] == [math.MaxInt32]
+//   - 64-bit: [math.MaxUint32] & [math.MaxInt64] == [math.MaxUint32]
+//
+// Only in the 32-bit case, the top bit becomes masked out, properly lowering
+// the limit.
+//
+// This makes use of untyped constants in Go to make sure the compiler has
+// enough space for computing this value.
+
 // MaxMessageLength is the maximum length of a message that can be sent or
 // received.
 //

--- a/internal/gossiphttp/message_test.go
+++ b/internal/gossiphttp/message_test.go
@@ -20,7 +20,7 @@ func Fuzz_message(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, data []byte) {
 		// Ignore slices longer than the max message length.
-		if len(data) > math.MaxUint32 {
+		if len(data) > MaxMessageLength {
 			t.Skip()
 		}
 
@@ -60,8 +60,7 @@ func TestMessageRoundTrip(t *testing.T) {
 		bytes.Repeat([]byte("a"), math.MaxUint16),
 		bytes.Repeat([]byte("b"), 100),
 		bytes.Repeat([]byte("c"), math.MaxUint16+1),
-		bytes.Repeat([]byte("d"), 1000000),
-		bytes.Repeat([]byte("e"), math.MaxUint32),
+		bytes.Repeat([]byte("d"), 1_000_000),
 	}
 
 	for i, message := range testMessages {
@@ -111,12 +110,7 @@ func TestWriteMessageMagicByte(t *testing.T) {
 		},
 		{
 			name:          "large message (32-bit)",
-			message:       bytes.Repeat([]byte("a"), 1000000),
-			expectedMagic: magic32,
-		},
-		{
-			name:          "max uint32 message (32-bit)",
-			message:       bytes.Repeat([]byte("a"), math.MaxUint32),
+			message:       bytes.Repeat([]byte("a"), 1_000_000),
 			expectedMagic: magic32,
 		},
 	}


### PR DESCRIPTION
Dependencies like grafana/loki use 32-bit builds, and need ckit to work for 32-bit platforms.

An update to #97 is needed to get tests to run as expected on 32-bit platforms. Test cases which generated the full message size needed to be removed, as they were using 8 GiB of memory on 64-bit platforms, and kept getting terminated by runners.